### PR TITLE
feat: Add lazy loading mode for database connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,12 +86,14 @@ The server follows Clean Architecture principles with these layers:
 ## Features
 
 - **Simultaneous Multi-Database Support**: Connect to multiple MySQL and PostgreSQL databases concurrently
+- **Lazy Loading Mode**: Defer connection establishment until first use - perfect for setups with 10+ databases (enable with `--lazy-loading` flag)
 - **Database-Specific Tool Generation**: Auto-creates specialized tools for each connected database
 - **Clean Architecture**: Modular design with clear separation of concerns
 - **OpenAI Agents SDK Compatibility**: Full compatibility for seamless AI assistant integration
 - **Dynamic Database Tools**: Execute queries, run statements, manage transactions, explore schemas, analyze performance
 - **Unified Interface**: Consistent interaction patterns across different database types
 - **Connection Management**: Simple configuration for multiple database connections
+- **Health Check**: Automatic validation of database connectivity on startup
 
 ## Supported Databases
 
@@ -211,6 +213,9 @@ Create a `config.json` file with your database connections:
 
 # SSE transport options
 ./bin/server -t sse -host <hostname> -port <port> -c <config-file>
+
+# Lazy loading mode (recommended for 10+ databases)
+./bin/server -t stdio -c <config-file> --lazy-loading
 
 # Customize log directory (useful for multi-project setups)
 ./bin/server -t stdio -c <config-file> -log-dir /tmp/db-mcp-logs

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -66,6 +66,7 @@ func main() {
 	serverHost := flag.String("h", "localhost", "Server host for SSE transport")
 	dbConfigJSON := flag.String("db-config", "", "JSON string with database configuration")
 	logLevel := flag.String("log-level", "info", "Log level (debug, info, warn, error)")
+	lazyLoading := flag.Bool("lazy-loading", false, "Enable lazy loading: connections established on first use (recommended for 10+ databases)")
 	logDir := flag.String("log-dir", "", "Directory for log files (default: ./logs in current directory)")
 	flag.Parse()
 
@@ -126,11 +127,15 @@ func main() {
 
 	// Initialize database connection from config
 	dbConfig := &dbtools.Config{
-		ConfigFile: cfg.ConfigPath,
+		ConfigFile:  cfg.ConfigPath,
+		LazyLoading: *lazyLoading,
 	}
 
 	// Ensure database configuration exists
 	logger.Info("Using database configuration from: %s", cfg.ConfigPath)
+	if *lazyLoading {
+		logger.Info("Lazy loading enabled: database connections will be established on first use")
+	}
 
 	// Try to initialize database from config
 	if err := dbtools.InitDatabase(dbConfig); err != nil {

--- a/internal/delivery/mcp/context/timescale_context_test.go
+++ b/internal/delivery/mcp/context/timescale_context_test.go
@@ -51,6 +51,12 @@ func (m *MockDatabaseUseCase) ListDatabases() []string {
 	return args.Get(0).([]string)
 }
 
+// IsLazyLoading mocks the IsLazyLoading method
+func (m *MockDatabaseUseCase) IsLazyLoading() bool {
+	args := m.Called()
+	return args.Bool(0)
+}
+
 func TestTimescaleDBContextProvider(t *testing.T) {
 	// Create a mock use case provider
 	mockUseCase := new(MockDatabaseUseCase)

--- a/internal/delivery/mcp/mock_test.go
+++ b/internal/delivery/mcp/mock_test.go
@@ -46,3 +46,9 @@ func (m *MockDatabaseUseCase) ListDatabases() []string {
 	args := m.Called()
 	return args.Get(0).([]string)
 }
+
+// IsLazyLoading mocks the IsLazyLoading method
+func (m *MockDatabaseUseCase) IsLazyLoading() bool {
+	args := m.Called()
+	return args.Bool(0)
+}

--- a/internal/delivery/mcp/timescale_tools_test.go
+++ b/internal/delivery/mcp/timescale_tools_test.go
@@ -53,6 +53,12 @@ func (m *MockDatabaseUseCase) ListDatabases() []string {
 	return args.Get(0).([]string)
 }
 
+// IsLazyLoading mocks the IsLazyLoading method
+func (m *MockDatabaseUseCase) IsLazyLoading() bool {
+	args := m.Called()
+	return args.Bool(0)
+}
+
 func TestTimescaleDBTool(t *testing.T) {
 	tool := mcp.NewTimescaleDBTool()
 	assert.Equal(t, "timescaledb", tool.GetName())

--- a/internal/delivery/mcp/tool_types.go
+++ b/internal/delivery/mcp/tool_types.go
@@ -68,6 +68,7 @@ type UseCaseProvider interface {
 	GetDatabaseInfo(dbID string) (map[string]interface{}, error)
 	ListDatabases() []string
 	GetDatabaseType(dbID string) (string, error)
+	IsLazyLoading() bool
 }
 
 // BaseToolType provides common functionality for tool types

--- a/internal/domain/database.go
+++ b/internal/domain/database.go
@@ -111,4 +111,5 @@ type DatabaseRepository interface {
 	GetDatabase(id string) (Database, error)
 	ListDatabases() []string
 	GetDatabaseType(id string) (string, error)
+	IsLazyLoading() bool
 }

--- a/internal/repository/database_repository.go
+++ b/internal/repository/database_repository.go
@@ -3,7 +3,6 @@ package repository
 import (
 	"context"
 	"database/sql"
-	"fmt"
 
 	"github.com/FreePeak/db-mcp-server/internal/domain"
 	"github.com/FreePeak/db-mcp-server/pkg/dbtools"
@@ -39,25 +38,15 @@ func (r *DatabaseRepository) ListDatabases() []string {
 
 // GetDatabaseType returns the type of a database by ID
 func (r *DatabaseRepository) GetDatabaseType(id string) (string, error) {
-	// Get the database connection to check its actual driver
-	db, err := dbtools.GetDatabase(id)
-	if err != nil {
-		return "", fmt.Errorf("failed to get database connection for type detection: %w", err)
-	}
+	// Read database type from configuration without establishing a connection
+	// The type is already validated when the connection is created, so we can trust it
+	// This is especially important for lazy loading to avoid unnecessary connections during startup
+	return dbtools.GetDatabaseType(id)
+}
 
-	// Use the actual driver name to determine database type
-	driverName := db.DriverName()
-
-	switch driverName {
-	case "postgres":
-		return "postgres", nil
-	case "mysql":
-		return "mysql", nil
-	default:
-		// Unknown database type - return the actual driver name and let the caller handle it
-		// Never default to MySQL as that can cause SQL dialect issues
-		return driverName, nil
-	}
+// IsLazyLoading returns whether lazy loading mode is enabled
+func (r *DatabaseRepository) IsLazyLoading() bool {
+	return dbtools.IsLazyLoading()
 }
 
 // DatabaseAdapter adapts the db.Database to the domain.Database interface

--- a/internal/usecase/database_usecase.go
+++ b/internal/usecase/database_usecase.go
@@ -342,3 +342,8 @@ func timeNowUnix() int64 {
 func (uc *DatabaseUseCase) GetDatabaseType(dbID string) (string, error) {
 	return uc.repo.GetDatabaseType(dbID)
 }
+
+// IsLazyLoading returns whether lazy loading mode is enabled
+func (uc *DatabaseUseCase) IsLazyLoading() bool {
+	return uc.repo.IsLazyLoading()
+}

--- a/pkg/db/manager_test.go
+++ b/pkg/db/manager_test.go
@@ -1,0 +1,567 @@
+package db
+
+import (
+	"encoding/json"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestNewDBManager(t *testing.T) {
+	manager := NewDBManager()
+
+	if manager == nil {
+		t.Fatal("NewDBManager returned nil")
+	}
+
+	if manager.connections == nil {
+		t.Error("connections map not initialized")
+	}
+
+	if manager.configs == nil {
+		t.Error("configs map not initialized")
+	}
+
+	if manager.lazyLoading {
+		t.Error("lazy loading should be disabled by default")
+	}
+}
+
+func TestSetLazyLoading(t *testing.T) {
+	manager := NewDBManager()
+
+	// Test enabling lazy loading (direct field access to avoid logger dependency)
+	manager.mu.Lock()
+	manager.lazyLoading = true
+	manager.mu.Unlock()
+
+	if !manager.IsLazyLoading() {
+		t.Error("lazy loading should be enabled")
+	}
+
+	// Test disabling lazy loading
+	manager.mu.Lock()
+	manager.lazyLoading = false
+	manager.mu.Unlock()
+
+	if manager.IsLazyLoading() {
+		t.Error("lazy loading should be disabled")
+	}
+}
+
+func TestLoadConfig(t *testing.T) {
+	tests := []struct {
+		name        string
+		configJSON  string
+		expectError bool
+		errorMsg    string
+	}{
+		{
+			name: "valid postgres config",
+			configJSON: `{
+				"connections": [
+					{
+						"id": "test-postgres",
+						"type": "postgres",
+						"host": "localhost",
+						"port": 5432,
+						"user": "testuser",
+						"password": "testpass",
+						"name": "testdb"
+					}
+				]
+			}`,
+			expectError: false,
+		},
+		{
+			name: "valid mysql config",
+			configJSON: `{
+				"connections": [
+					{
+						"id": "test-mysql",
+						"type": "mysql",
+						"host": "localhost",
+						"port": 3306,
+						"user": "testuser",
+						"password": "testpass",
+						"name": "testdb"
+					}
+				]
+			}`,
+			expectError: false,
+		},
+		{
+			name: "multiple databases",
+			configJSON: `{
+				"connections": [
+					{
+						"id": "db1",
+						"type": "postgres",
+						"host": "localhost",
+						"port": 5432,
+						"user": "user1",
+						"password": "pass1",
+						"name": "db1"
+					},
+					{
+						"id": "db2",
+						"type": "mysql",
+						"host": "localhost",
+						"port": 3306,
+						"user": "user2",
+						"password": "pass2",
+						"name": "db2"
+					}
+				]
+			}`,
+			expectError: false,
+		},
+		{
+			name:        "invalid json",
+			configJSON:  `{invalid json}`,
+			expectError: true,
+			errorMsg:    "failed to parse config JSON",
+		},
+		{
+			name: "empty database id",
+			configJSON: `{
+				"connections": [
+					{
+						"id": "",
+						"type": "postgres",
+						"host": "localhost",
+						"port": 5432,
+						"user": "testuser",
+						"password": "testpass",
+						"name": "testdb"
+					}
+				]
+			}`,
+			expectError: true,
+			errorMsg:    "database connection ID cannot be empty",
+		},
+		{
+			name: "unsupported database type",
+			configJSON: `{
+				"connections": [
+					{
+						"id": "test-db",
+						"type": "mongodb",
+						"host": "localhost",
+						"port": 27017,
+						"user": "testuser",
+						"password": "testpass",
+						"name": "testdb"
+					}
+				]
+			}`,
+			expectError: true,
+			errorMsg:    "unsupported database type",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			manager := NewDBManager()
+			err := manager.LoadConfig([]byte(tt.configJSON))
+
+			if tt.expectError {
+				if err == nil {
+					t.Errorf("expected error containing '%s', got nil", tt.errorMsg)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("unexpected error: %v", err)
+				}
+			}
+		})
+	}
+}
+
+func TestGetDatabaseType(t *testing.T) {
+	manager := NewDBManager()
+
+	// Load test config
+	configJSON := `{
+		"connections": [
+			{
+				"id": "postgres-db",
+				"type": "postgres",
+				"host": "localhost",
+				"port": 5432,
+				"user": "testuser",
+				"password": "testpass",
+				"name": "testdb"
+			},
+			{
+				"id": "mysql-db",
+				"type": "mysql",
+				"host": "localhost",
+				"port": 3306,
+				"user": "testuser",
+				"password": "testpass",
+				"name": "testdb"
+			}
+		]
+	}`
+
+	if err := manager.LoadConfig([]byte(configJSON)); err != nil {
+		t.Fatalf("failed to load config: %v", err)
+	}
+
+	tests := []struct {
+		name         string
+		dbID         string
+		expectedType string
+		expectError  bool
+	}{
+		{
+			name:         "get postgres type",
+			dbID:         "postgres-db",
+			expectedType: "postgres",
+			expectError:  false,
+		},
+		{
+			name:         "get mysql type",
+			dbID:         "mysql-db",
+			expectedType: "mysql",
+			expectError:  false,
+		},
+		{
+			name:        "non-existent database",
+			dbID:        "non-existent",
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dbType, err := manager.GetDatabaseType(tt.dbID)
+
+			if tt.expectError {
+				if err == nil {
+					t.Error("expected error, got nil")
+				}
+			} else {
+				if err != nil {
+					t.Errorf("unexpected error: %v", err)
+				}
+				if dbType != tt.expectedType {
+					t.Errorf("expected type %s, got %s", tt.expectedType, dbType)
+				}
+			}
+		})
+	}
+}
+
+func TestListDatabases(t *testing.T) {
+	manager := NewDBManager()
+
+	// Initially empty
+	if len(manager.ListDatabases()) != 0 {
+		t.Error("expected empty database list")
+	}
+
+	// Load config with multiple databases
+	configJSON := `{
+		"connections": [
+			{"id": "db1", "type": "postgres", "host": "localhost", "port": 5432, "user": "user", "password": "pass", "name": "db1"},
+			{"id": "db2", "type": "mysql", "host": "localhost", "port": 3306, "user": "user", "password": "pass", "name": "db2"},
+			{"id": "db3", "type": "postgres", "host": "localhost", "port": 5432, "user": "user", "password": "pass", "name": "db3"}
+		]
+	}`
+
+	if err := manager.LoadConfig([]byte(configJSON)); err != nil {
+		t.Fatalf("failed to load config: %v", err)
+	}
+
+	dbs := manager.ListDatabases()
+	if len(dbs) != 3 {
+		t.Errorf("expected 3 databases, got %d", len(dbs))
+	}
+
+	// Check that all database IDs are present
+	dbMap := make(map[string]bool)
+	for _, id := range dbs {
+		dbMap[id] = true
+	}
+
+	expectedIDs := []string{"db1", "db2", "db3"}
+	for _, id := range expectedIDs {
+		if !dbMap[id] {
+			t.Errorf("expected database ID %s not found in list", id)
+		}
+	}
+}
+
+func TestGetDatabaseConfig(t *testing.T) {
+	manager := NewDBManager()
+
+	configJSON := `{
+		"connections": [
+			{
+				"id": "test-db",
+				"type": "postgres",
+				"host": "test-host",
+				"port": 5432,
+				"user": "testuser",
+				"password": "testpass",
+				"name": "testdb",
+				"ssl_mode": "require",
+				"max_open_conns": 10,
+				"max_idle_conns": 5
+			}
+		]
+	}`
+
+	if err := manager.LoadConfig([]byte(configJSON)); err != nil {
+		t.Fatalf("failed to load config: %v", err)
+	}
+
+	// Test getting existing config
+	cfg, err := manager.GetDatabaseConfig("test-db")
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	if cfg.ID != "test-db" {
+		t.Errorf("expected ID 'test-db', got '%s'", cfg.ID)
+	}
+	if cfg.Type != "postgres" {
+		t.Errorf("expected type 'postgres', got '%s'", cfg.Type)
+	}
+	if cfg.Host != "test-host" {
+		t.Errorf("expected host 'test-host', got '%s'", cfg.Host)
+	}
+	if cfg.MaxOpenConns != 10 {
+		t.Errorf("expected MaxOpenConns 10, got %d", cfg.MaxOpenConns)
+	}
+
+	// Test getting non-existent config
+	_, err = manager.GetDatabaseConfig("non-existent")
+	if err == nil {
+		t.Error("expected error for non-existent database, got nil")
+	}
+}
+
+func TestBuildDatabaseConfig(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    DatabaseConnectionConfig
+		validate func(t *testing.T, cfg Config)
+	}{
+		{
+			name: "postgres with ssl options",
+			input: DatabaseConnectionConfig{
+				ID:              "test-db",
+				Type:            "postgres",
+				Host:            "localhost",
+				Port:            5432,
+				User:            "testuser",
+				Password:        "testpass",
+				Name:            "testdb",
+				SSLMode:         "require",
+				SSLCert:         "/path/to/cert",
+				SSLKey:          "/path/to/key",
+				SSLRootCert:     "/path/to/root",
+				ApplicationName: "test-app",
+				ConnectTimeout:  30,
+				QueryTimeout:    60,
+			},
+			validate: func(t *testing.T, cfg Config) {
+				if cfg.Type != "postgres" {
+					t.Errorf("expected type 'postgres', got '%s'", cfg.Type)
+				}
+				if cfg.SSLMode != "require" {
+					t.Errorf("expected SSLMode 'require', got '%s'", cfg.SSLMode)
+				}
+				if cfg.SSLCert != "/path/to/cert" {
+					t.Errorf("expected SSLCert '/path/to/cert', got '%s'", cfg.SSLCert)
+				}
+				if cfg.ApplicationName != "test-app" {
+					t.Errorf("expected ApplicationName 'test-app', got '%s'", cfg.ApplicationName)
+				}
+				if cfg.ConnectTimeout != 30 {
+					t.Errorf("expected ConnectTimeout 30, got %d", cfg.ConnectTimeout)
+				}
+				if cfg.QueryTimeout != 60 {
+					t.Errorf("expected QueryTimeout 60, got %d", cfg.QueryTimeout)
+				}
+			},
+		},
+		{
+			name: "mysql with connection pool settings",
+			input: DatabaseConnectionConfig{
+				ID:              "mysql-db",
+				Type:            "mysql",
+				Host:            "localhost",
+				Port:            3306,
+				User:            "testuser",
+				Password:        "testpass",
+				Name:            "testdb",
+				MaxOpenConns:    25,
+				MaxIdleConns:    10,
+				ConnMaxLifetime: 300,
+				ConnMaxIdleTime: 60,
+			},
+			validate: func(t *testing.T, cfg Config) {
+				if cfg.Type != "mysql" {
+					t.Errorf("expected type 'mysql', got '%s'", cfg.Type)
+				}
+				if cfg.MaxOpenConns != 25 {
+					t.Errorf("expected MaxOpenConns 25, got %d", cfg.MaxOpenConns)
+				}
+				if cfg.MaxIdleConns != 10 {
+					t.Errorf("expected MaxIdleConns 10, got %d", cfg.MaxIdleConns)
+				}
+				if cfg.ConnMaxLifetime != 300*time.Second {
+					t.Errorf("expected ConnMaxLifetime 300s, got %v", cfg.ConnMaxLifetime)
+				}
+				if cfg.ConnMaxIdleTime != 60*time.Second {
+					t.Errorf("expected ConnMaxIdleTime 60s, got %v", cfg.ConnMaxIdleTime)
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := buildDatabaseConfig(tt.input)
+			tt.validate(t, cfg)
+		})
+	}
+}
+
+func TestLazyLoadingConcurrency(t *testing.T) {
+	manager := NewDBManager()
+	// Enable lazy loading (direct field access to avoid logger dependency)
+	manager.mu.Lock()
+	manager.lazyLoading = true
+	manager.mu.Unlock()
+
+	// Load config with multiple databases
+	configJSON := `{
+		"connections": [
+			{"id": "db1", "type": "postgres", "host": "localhost", "port": 5432, "user": "user", "password": "pass", "name": "db1"},
+			{"id": "db2", "type": "postgres", "host": "localhost", "port": 5432, "user": "user", "password": "pass", "name": "db2"},
+			{"id": "db3", "type": "postgres", "host": "localhost", "port": 5432, "user": "user", "password": "pass", "name": "db3"}
+		]
+	}`
+
+	if err := manager.LoadConfig([]byte(configJSON)); err != nil {
+		t.Fatalf("failed to load config: %v", err)
+	}
+
+	// Verify lazy loading is enabled
+	if !manager.IsLazyLoading() {
+		t.Fatal("lazy loading should be enabled")
+	}
+
+	// Test concurrent access to GetDatabaseType (should not panic with race conditions)
+	var wg sync.WaitGroup
+	numGoroutines := 10
+	numIterations := 100
+
+	for i := 0; i < numGoroutines; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < numIterations; j++ {
+				// Rotate through database IDs
+				dbID := []string{"db1", "db2", "db3"}[j%3]
+				_, err := manager.GetDatabaseType(dbID)
+				if err != nil {
+					t.Errorf("GetDatabaseType failed: %v", err)
+				}
+			}
+		}()
+	}
+
+	wg.Wait()
+}
+
+func TestGetConnectedDatabases(t *testing.T) {
+	manager := NewDBManager()
+
+	// Initially empty
+	if len(manager.GetConnectedDatabases()) != 0 {
+		t.Error("expected no connected databases initially")
+	}
+
+	// Load config
+	configJSON := `{
+		"connections": [
+			{"id": "db1", "type": "postgres", "host": "localhost", "port": 5432, "user": "user", "password": "pass", "name": "db1"},
+			{"id": "db2", "type": "postgres", "host": "localhost", "port": 5432, "user": "user", "password": "pass", "name": "db2"}
+		]
+	}`
+
+	if err := manager.LoadConfig([]byte(configJSON)); err != nil {
+		t.Fatalf("failed to load config: %v", err)
+	}
+
+	// With lazy loading enabled, should have no connections initially
+	manager.mu.Lock()
+	manager.lazyLoading = true
+	manager.mu.Unlock()
+	if len(manager.GetConnectedDatabases()) != 0 {
+		t.Error("expected no connected databases with lazy loading before Connect()")
+	}
+
+	// Note: We skip calling Connect() since it requires:
+	// 1. Logger to be initialized (would panic in test environment)
+	// 2. Actual database connectivity (not available in unit tests)
+	// The connection establishment logic is tested through integration tests
+}
+
+func TestConfigMarshaling(t *testing.T) {
+	// Test that DatabaseConnectionConfig can be properly marshaled/unmarshaled
+	original := DatabaseConnectionConfig{
+		ID:                 "test-db",
+		Type:               "postgres",
+		Host:               "localhost",
+		Port:               5432,
+		User:               "testuser",
+		Password:           "testpass",
+		Name:               "testdb",
+		SSLMode:            "require",
+		SSLCert:            "/path/to/cert",
+		SSLKey:             "/path/to/key",
+		SSLRootCert:        "/path/to/root",
+		ApplicationName:    "test-app",
+		ConnectTimeout:     30,
+		QueryTimeout:       60,
+		TargetSessionAttrs: "read-write",
+		Options:            map[string]string{"option1": "value1"},
+		MaxOpenConns:       10,
+		MaxIdleConns:       5,
+		ConnMaxLifetime:    300,
+		ConnMaxIdleTime:    60,
+	}
+
+	// Marshal to JSON
+	data, err := json.Marshal(original)
+	if err != nil {
+		t.Fatalf("failed to marshal config: %v", err)
+	}
+
+	// Unmarshal back
+	var unmarshaled DatabaseConnectionConfig
+	if err := json.Unmarshal(data, &unmarshaled); err != nil {
+		t.Fatalf("failed to unmarshal config: %v", err)
+	}
+
+	// Compare key fields
+	if unmarshaled.ID != original.ID {
+		t.Errorf("ID mismatch: expected %s, got %s", original.ID, unmarshaled.ID)
+	}
+	if unmarshaled.Type != original.Type {
+		t.Errorf("Type mismatch: expected %s, got %s", original.Type, unmarshaled.Type)
+	}
+	if unmarshaled.SSLMode != original.SSLMode {
+		t.Errorf("SSLMode mismatch: expected %s, got %s", original.SSLMode, unmarshaled.SSLMode)
+	}
+	if unmarshaled.MaxOpenConns != original.MaxOpenConns {
+		t.Errorf("MaxOpenConns mismatch: expected %d, got %d", original.MaxOpenConns, unmarshaled.MaxOpenConns)
+	}
+}


### PR DESCRIPTION
# Add lazy loading mode for database connections

## What

Adds optional `--lazy-loading` flag to defer database connection establishment until first use, reducing startup time and memory usage for configurations with many databases.

## Why

Running multiple MCP server instances with 50+ database configurations causes:
- Slow startup (5-8s) connecting to all databases eagerly
- High memory usage (~1.2GB) maintaining unused connections
- WSL crashes under load from excessive concurrent connections

Lazy loading addresses this by connecting on-demand while maintaining a health check to validate credentials on startup.

## How

**Core implementation:**
- `Manager.Connect()` performs health check by connecting to one database per type (postgres/mysql) when lazy loading enabled
- `Manager.GetDatabase()` establishes connections on-demand using double-checked locking for thread safety
- `GetDatabaseType()` reads from config instead of connecting (critical fix to avoid connections during tool registration)

**Flag propagation:**
- CLI flag `--lazy-loading` sets mode in dbtools layer
- `IsLazyLoading()` method propagated through domain/usecase layers for MCP tool access
- Tool registry skips TimescaleDB detection when lazy loading enabled

## Changes

- Added `Manager.SetLazyLoading()`, `connectOnDemand()`, health check logic in `Connect()`
- Fixed `DatabaseRepository.GetDatabaseType()` to read from config without connecting
- Added `dbtools.GetDatabaseType()` to expose type lookup without connection
- Added 10 unit tests covering config loading, lazy mode, thread-safety (567 lines)
- Updated README.md with flag documentation

## Testing

- Unit tests validate lazy mode toggle, config parsing, concurrent access (10 goroutines × 100 iterations)
- Manually verified with 48 databases: 1 connection at startup (health check), 2 after first query (on-demand)
- Full test suite passes (`go test ./...`)

## Breaking Changes

None. Lazy loading is opt-in via `--lazy-loading` flag. Default behavior unchanged.

## Usage

```bash
db-mcp-server -t stdio --config config.json --lazy-loading
```
