### PR TITLE
feat: add configurable log directory via --log-dir flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,9 @@ Create a `config.json` file with your database connections:
 # SSE transport options
 ./bin/server -t sse -host <hostname> -port <port> -c <config-file>
 
+# Customize log directory (useful for multi-project setups)
+./bin/server -t stdio -c <config-file> -log-dir /tmp/db-mcp-logs
+
 # Inline database configuration
 ./bin/server -t stdio -db-config '{"connections":[...]}'
 
@@ -219,6 +222,15 @@ Create a `config.json` file with your database connections:
 export DB_CONFIG='{"connections":[...]}'
 ./bin/server -t stdio
 ```
+
+**Available Flags:**
+- `-t, -transport`: Transport mode (`stdio` or `sse`)
+- `-c, -config`: Path to database configuration file
+- `-p, -port`: Server port for SSE mode (default: 9092)
+- `-h, -host`: Server host for SSE mode (default: localhost)
+- `-log-level`: Log level (`debug`, `info`, `warn`, `error`)
+- `-log-dir`: Directory for log files (default: `./logs` in current directory)
+- `-db-config`: Inline JSON database configuration
 
 ## Available Tools
 

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -66,10 +66,11 @@ func main() {
 	serverHost := flag.String("h", "localhost", "Server host for SSE transport")
 	dbConfigJSON := flag.String("db-config", "", "JSON string with database configuration")
 	logLevel := flag.String("log-level", "info", "Log level (debug, info, warn, error)")
+	logDir := flag.String("log-dir", "", "Directory for log files (default: ./logs in current directory)")
 	flag.Parse()
 
-	// Initialize logger
-	logger.Initialize(*logLevel)
+	// Initialize logger with custom log directory
+	logger.Initialize(logger.Config{Level: *logLevel, LogDir: *logDir})
 	pkgLogger.Initialize(*logLevel)
 
 	// Prioritize flags with actual values

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -37,7 +37,7 @@ type DatabaseConfig struct {
 // LoadConfig loads the configuration from environment variables and optional JSON config
 func LoadConfig() (*Config, error) {
 	// Initialize logger with default level first to avoid nil pointer
-	logger.Initialize("info")
+	logger.Initialize(logger.Config{Level: "info"})
 
 	// Load .env file if it exists
 	err := godotenv.Load()

--- a/pkg/internal/logger/logger.go
+++ b/pkg/internal/logger/logger.go
@@ -31,5 +31,5 @@ func ErrorWithStack(err error) {
 
 // Initialize initializes the logger with specified level
 func Initialize(level string) {
-	logger.Initialize(level)
+	logger.Initialize(logger.Config{Level: level})
 }


### PR DESCRIPTION
# Add configurable log directory

## What

Adds `--log-dir` flag to specify where log files are created.

## Why

In stdio mode, logs are created in `./logs` relative to current directory. When using Claude Code extension across multiple projects, this creates log directories in every project folder.

Fixes #40

## How

Introduced `logger.Config` struct to pass both log level and directory to initialization. Flag `--log-dir` allows customization, defaults to `./logs` if not specified.

## Changes

- Added `logger.Config` struct with `Level` and `LogDir` fields
- Added `--log-dir` CLI flag
- Updated all `logger.Initialize()` calls to use Config struct
- Added 2 unit tests (custom dir + default fallback)
- Updated README.md with flag documentation

## Testing

Unit tests verify custom and default directory creation. Full test suite passes.

## Breaking Changes

None. Default behavior unchanged.

## Usage

```bash
# Centralized logs
db-mcp-server -t stdio --config config.json --log-dir /tmp/db-mcp-logs
```