### PR TITLE
fix: respect -log-dir flag in stdio mode

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -114,7 +114,7 @@ func main() {
 	}
 
 	// Load configuration after environment variables are set
-	cfg, err := config.LoadConfig()
+	cfg, err := config.LoadConfig(*logDir)
 	if err != nil {
 		logger.Warn("Warning: Failed to load configuration: %v", err)
 		// Create a default config if loading fails
@@ -267,8 +267,11 @@ func main() {
 		// We can only log to stderr in stdio mode - NEVER stdout
 		fmt.Fprintln(os.Stderr, "Starting STDIO server - all logging redirected to log files")
 
-		// Create logs directory if not exists
-		logsDir := "logs"
+		// Use custom log directory if provided, otherwise default to "logs"
+		logsDir := *logDir
+		if logsDir == "" {
+			logsDir = "logs"
+		}
 		if err := os.MkdirAll(logsDir, 0755); err != nil {
 			// Can't use logger.Warn as it might go to stdout
 			fmt.Fprintf(os.Stderr, "Failed to create logs directory: %v\n", err)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -35,9 +35,10 @@ type DatabaseConfig struct {
 }
 
 // LoadConfig loads the configuration from environment variables and optional JSON config
-func LoadConfig() (*Config, error) {
-	// Initialize logger with default level first to avoid nil pointer
-	logger.Initialize(logger.Config{Level: "info"})
+func LoadConfig(logDir string) (*Config, error) {
+	// Reinitialize logger with info level and custom log directory
+	// This ensures consistent logging throughout config loading regardless of initial setup
+	logger.Initialize(logger.Config{Level: "info", LogDir: logDir})
 
 	// Load .env file if it exists
 	err := godotenv.Load()

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -71,7 +71,7 @@ func TestLoadConfig(t *testing.T) {
 	}
 
 	// Test with default values (no .env file and no environment variables)
-	config, err := LoadConfig()
+	config, err := LoadConfig("")
 	assert.NoError(t, err)
 	assert.Equal(t, 9090, config.ServerPort)
 	assert.Equal(t, "sse", config.TransportMode)
@@ -129,7 +129,7 @@ func TestLoadConfig(t *testing.T) {
 		}
 	}()
 
-	config, err = LoadConfig()
+	config, err = LoadConfig("")
 	assert.NoError(t, err)
 	assert.Equal(t, 8080, config.ServerPort)
 	assert.Equal(t, "stdio", config.TransportMode)


### PR DESCRIPTION
Fixes #40

## Problem

The `-log-dir` flag was being ignored in stdio mode, causing logs to be created in `./logs/` within the current working directory instead of the specified custom directory. This resulted in multiple log directories being created across different repository locations.

## Root Cause

The logger was being reinitialized without the `logDir` parameter in two places:

1. **`LoadConfig()`** was reinitializing the logger without preserving the custom log directory
2. **stdio transport case** was hardcoding `"logs"` directory instead of using the flag value

## Changes

- ✅ Pass `logDir` parameter to `LoadConfig()` so it can reinitialize with correct directory
- ✅ Update stdio case to use `-log-dir` flag value instead of hardcoded `"logs"`
- ✅ Update tests to pass empty `logDir` (use default behavior)

## Testing

Tested with Claude Code MCP integration:
- Before: Logs created in `./logs/` in repository directory
- After: All logs correctly created in `/tmp/db-mcp-logs/` as specified by `-log-dir` flag
- Verified `stdio-server.log` also respects the custom directory

## Impact

This ensures that when using the `-log-dir` flag, ALL log files (both from the logger and stdio server) are created in the specified directory, preventing log pollution across multiple working directories.