### PR TITLE
fix(ci): remove unnecessary npm install step from publish workflow

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -111,9 +111,6 @@ jobs:
           node-version: '20'
           registry-url: 'https://registry.npmjs.org'
 
-      - name: Install dependencies
-        run: npm install
-
       - name: Publish to NPM
         run: |
           VERSION=${{ needs.get-version.outputs.version }}


### PR DESCRIPTION
The package has no npm dependencies and only uses Node.js built-in modules. The npm install step was causing the workflow to fail.