### PR TITLE
feat: add --unified-tools flag for consolidated MCP tool registration

### DIFF
--- a/internal/delivery/mcp/timescale_tool.go
+++ b/internal/delivery/mcp/timescale_tool.go
@@ -442,6 +442,113 @@ func (t *TimescaleDBTool) CreateContinuousAggregatePolicyRemoveTool(name string,
 	)
 }
 
+// CreateUnifiedTool creates a unified TimescaleDB tool (delegates to CreateTool with empty dbID)
+func (t *TimescaleDBTool) CreateUnifiedTool(name string, dbList []string) interface{} {
+	desc := fmt.Sprintf("%s. Available databases: %s", t.description, strings.Join(dbList, ", "))
+	return cortextools.NewTool(
+		name,
+		cortextools.WithDescription(desc),
+		cortextools.WithString("database",
+			cortextools.Description(fmt.Sprintf("Database ID to use. Available: %s", strings.Join(dbList, ", "))),
+			cortextools.Required(),
+		),
+		cortextools.WithString("operation",
+			cortextools.Description("TimescaleDB operation to perform"),
+			cortextools.Required(),
+		),
+		cortextools.WithString("target_table",
+			cortextools.Description("The table to perform the operation on"),
+		),
+	)
+}
+
+// CreateUnifiedTimeSeriesQueryTool creates a unified time-series query tool with database parameter
+func (t *TimescaleDBTool) CreateUnifiedTimeSeriesQueryTool(name string, dbList []string) interface{} {
+	desc := fmt.Sprintf("Execute time-series queries on TimescaleDB. Available databases: %s", strings.Join(dbList, ", "))
+	return cortextools.NewTool(
+		name,
+		cortextools.WithDescription(desc),
+		cortextools.WithString("database",
+			cortextools.Description(fmt.Sprintf("Database ID to use. Available: %s", strings.Join(dbList, ", "))),
+			cortextools.Required(),
+		),
+		cortextools.WithString("operation",
+			cortextools.Description("The operation must be 'time_series_query'"),
+			cortextools.Required(),
+		),
+		cortextools.WithString("target_table",
+			cortextools.Description("The table to query"),
+			cortextools.Required(),
+		),
+		cortextools.WithString("time_column",
+			cortextools.Description("The timestamp column for time bucketing"),
+			cortextools.Required(),
+		),
+		cortextools.WithString("bucket_interval",
+			cortextools.Description("Time bucket interval (e.g., '1 hour', '1 day')"),
+			cortextools.Required(),
+		),
+		cortextools.WithString("start_time",
+			cortextools.Description("Start of time range (e.g., '2023-01-01')"),
+		),
+		cortextools.WithString("end_time",
+			cortextools.Description("End of time range (e.g., '2023-01-31')"),
+		),
+		cortextools.WithString("aggregations",
+			cortextools.Description("Comma-separated list of aggregations (e.g., 'AVG(temp),MAX(temp),COUNT(*)')"),
+		),
+		cortextools.WithString("where_condition",
+			cortextools.Description("Additional WHERE conditions"),
+		),
+		cortextools.WithString("group_by",
+			cortextools.Description("Additional GROUP BY columns (comma-separated)"),
+		),
+		cortextools.WithString("order_by",
+			cortextools.Description("Order by clause (default: time_bucket)"),
+		),
+		cortextools.WithString("window_functions",
+			cortextools.Description("Window functions to include (e.g. 'LAG(value) OVER (ORDER BY time_bucket) AS prev_value')"),
+		),
+		cortextools.WithString("limit",
+			cortextools.Description("Maximum number of rows to return"),
+		),
+		cortextools.WithBoolean("format_pretty",
+			cortextools.Description("Whether to format the response in a more readable way"),
+		),
+	)
+}
+
+// CreateUnifiedTimeSeriesAnalyzeTool creates a unified time-series analyze tool with database parameter
+func (t *TimescaleDBTool) CreateUnifiedTimeSeriesAnalyzeTool(name string, dbList []string) interface{} {
+	desc := fmt.Sprintf("Analyze time-series data patterns on TimescaleDB. Available databases: %s", strings.Join(dbList, ", "))
+	return cortextools.NewTool(
+		name,
+		cortextools.WithDescription(desc),
+		cortextools.WithString("database",
+			cortextools.Description(fmt.Sprintf("Database ID to use. Available: %s", strings.Join(dbList, ", "))),
+			cortextools.Required(),
+		),
+		cortextools.WithString("operation",
+			cortextools.Description("The operation must be 'analyze_time_series'"),
+			cortextools.Required(),
+		),
+		cortextools.WithString("target_table",
+			cortextools.Description("The table to analyze"),
+			cortextools.Required(),
+		),
+		cortextools.WithString("time_column",
+			cortextools.Description("The timestamp column"),
+			cortextools.Required(),
+		),
+		cortextools.WithString("start_time",
+			cortextools.Description("Start of time range (e.g., '2023-01-01')"),
+		),
+		cortextools.WithString("end_time",
+			cortextools.Description("End of time range (e.g., '2023-01-31')"),
+		),
+	)
+}
+
 // HandleRequest handles a tool request
 func (t *TimescaleDBTool) HandleRequest(ctx context.Context, request server.ToolCallRequest, dbID string, useCase UseCaseProvider) (interface{}, error) {
 	// Extract parameters from the request


### PR DESCRIPTION
## Summary

- Add `--unified-tools` flag that registers 6 shared tools (`query`, `execute`, `transaction`, `performance`, `schema`, `list_databases`) instead of generating per-database tools
- Each unified tool accepts a required `database` parameter with validation and list of available databases in the description
- Backward-compatible: without the flag, behavior is unchanged

## Problem

When connecting many databases (e.g. 30+), the server registers 5 tools per database — resulting in 150+ tools. Some MCP clients (Cursor, Windsurf) have limits on the number of tools or degrade in performance with large tool lists.

**Before (37 databases = 186 tools):**
```
query_dev_accounting, execute_dev_accounting, ...
query_dev_asset, execute_dev_asset, ...
... × 37 databases
```

**After with `--unified-tools` (37 databases = 6 tools):**
```
query, execute, transaction, performance, schema, list_databases
```

## Usage

```bash
# Default mode — per-database tools (no changes)
./db-mcp-server -c config.json

# Unified mode — shared tools with database parameter
./db-mcp-server -c config.json --unified-tools
```

Tool call in unified mode:
```json
{
  "tool": "query",
  "parameters": {
    "database": "dev_accounting",
    "query": "SELECT * FROM users LIMIT 10"
  }
}
```

## Validation

Missing `database` parameter:
```
database parameter is required. Available databases: dev_accounting, dev_asset, ...
```

Invalid database name:
```
database 'unknown_db' not found. Available databases: dev_accounting, dev_asset, ...
```

## Changes

| File | Change |
|------|--------|
| `cmd/server/main.go` | Add `--unified-tools` flag, pass to registry, update tool listing log |
| `internal/delivery/mcp/tool_types.go` | Add `CreateUnifiedTool` to `ToolType` interface and all implementations |
| `internal/delivery/mcp/tool_registry.go` | Add `unifiedMode`, `registerUnifiedTools`, `extractAndValidateDatabase` |
| `internal/delivery/mcp/timescale_tool.go` | Add unified variants for TimescaleDB time-series tools |

## Test plan

- [x] `go build ./cmd/server/` — builds without errors
- [x] `go test ./...` — all existing tests pass
- [x] Launch without `--unified-tools` — per-database tools registered (regression)
- [x] Launch with `--unified-tools` — 6 unified tools registered
- [x] Call `query` with valid `database` — executes successfully
- [x] Call `query` without `database` — error with available databases list
- [x] Call `query` with nonexistent `database` — error with available databases list
