### PR TITLE
fix: resolve SQLite paths relative to config file directory

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -118,6 +118,10 @@ func LoadConfig(logDir string) (*Config, error) {
 			return nil, fmt.Errorf("failed to parse config file %s: %w", config.ConfigPath, err)
 		}
 
+		// Resolve SQLite database paths relative to the config file directory
+		configDir := filepath.Dir(config.ConfigPath)
+		resolveSQLitePaths(&multiDBConfig, configDir)
+
 		config.MultiDBConfig = &multiDBConfig
 	} else {
 		logger.Info("Warning: Config file not found at %s, using environment variables", config.ConfigPath)
@@ -138,6 +142,22 @@ func LoadConfig(logDir string) (*Config, error) {
 	}
 
 	return config, nil
+}
+
+// resolveSQLitePaths resolves SQLite database_path values to absolute paths
+// relative to the config file directory
+func resolveSQLitePaths(multiDBConfig *db.MultiDBConfig, configDir string) {
+	if multiDBConfig == nil {
+		return
+	}
+
+	for i := range multiDBConfig.Connections {
+		conn := &multiDBConfig.Connections[i]
+		if conn.Type == "sqlite" && conn.DatabasePath != "" && !filepath.IsAbs(conn.DatabasePath) {
+			// Resolve relative path against config file directory
+			conn.DatabasePath = filepath.Join(configDir, conn.DatabasePath)
+		}
+	}
 }
 
 // getEnv gets an environment variable or returns a default value


### PR DESCRIPTION
## Summary
- Fix SQLite `database_path` relative path resolution to be relative to the config file location, not the server's working directory
- This fixes "database connection not found" errors when the server runs from a different directory than where the config file lives

## Root Cause
When the MCP server runs from `/tmp` (or any directory different from the config file location), relative SQLite paths like `./test.db` were being resolved from `/tmp` instead of from the config file's directory.

## Test plan
- [x] `go build ./...` passes
- [x] `golangci-lint run` passes
- [ ] Test SQLite query via MCP tools after PR is merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)