### PR TITLE
fix: prevent SQL injection in TimescaleDB functions

### DIFF
--- a/pkg/db/timescale/continuous_aggregate.go
+++ b/pkg/db/timescale/continuous_aggregate.go
@@ -50,7 +50,7 @@ func (t *DB) CreateContinuousAggregate(ctx context.Context, options ContinuousAg
 	}
 
 	// Add view name
-	builder.WriteString(options.ViewName)
+	builder.WriteString(sanitizeIdentifier(options.ViewName))
 	builder.WriteString("\n")
 
 	// Add WITH clause for materialized_only if requested
@@ -63,7 +63,7 @@ func (t *DB) CreateContinuousAggregate(ctx context.Context, options ContinuousAg
 
 	// Add time bucket
 	builder.WriteString(fmt.Sprintf("time_bucket('%s', %s) as time_bucket",
-		options.BucketInterval, options.TimeColumn))
+		options.BucketInterval, sanitizeIdentifier(options.TimeColumn)))
 
 	// Add aggregations
 	if len(options.Aggregations) > 0 {
@@ -74,7 +74,7 @@ func (t *DB) CreateContinuousAggregate(ctx context.Context, options ContinuousAg
 			}
 
 			builder.WriteString(fmt.Sprintf(",\n    %s(%s) as %s",
-				agg.Function, agg.Column, colName))
+				agg.Function, sanitizeIdentifier(agg.Column), sanitizeIdentifier(colName)))
 		}
 	} else {
 		// Default to count(*) if no aggregations specified
@@ -82,7 +82,7 @@ func (t *DB) CreateContinuousAggregate(ctx context.Context, options ContinuousAg
 	}
 
 	// Add FROM clause
-	builder.WriteString(fmt.Sprintf("\nFROM %s\n", options.SourceTable))
+	builder.WriteString(fmt.Sprintf("\nFROM %s\n", sanitizeIdentifier(options.SourceTable)))
 
 	// Add WHERE clause if specified
 	if options.WhereCondition != "" {
@@ -144,7 +144,7 @@ func (t *DB) RefreshContinuousAggregate(ctx context.Context, viewName, startTime
 	builder.WriteString("CALL refresh_continuous_aggregate(")
 
 	// Add view name
-	builder.WriteString(fmt.Sprintf("'%s'", viewName))
+	builder.WriteString(fmt.Sprintf("'%s'", sanitizeStringLiteral(viewName)))
 
 	// Add time range if specified
 	if startTime != "" && endTime != "" {
@@ -175,7 +175,7 @@ func (t *DB) AddContinuousAggregatePolicy(ctx context.Context, options Continuou
 	sql := fmt.Sprintf(
 		"SELECT add_continuous_aggregate_policy('%s', start_offset => INTERVAL '%s', "+
 			"end_offset => INTERVAL '%s', schedule_interval => INTERVAL '%s')",
-		options.ViewName,
+		sanitizeStringLiteral(options.ViewName),
 		options.Start,
 		options.End,
 		options.ScheduleInterval,
@@ -199,7 +199,7 @@ func (t *DB) RemoveContinuousAggregatePolicy(ctx context.Context, viewName strin
 	// Build policy removal SQL
 	sql := fmt.Sprintf(
 		"SELECT remove_continuous_aggregate_policy('%s')",
-		viewName,
+		sanitizeStringLiteral(viewName),
 	)
 
 	// Execute the statement
@@ -220,7 +220,7 @@ func (t *DB) DropContinuousAggregate(ctx context.Context, viewName string, casca
 	var builder strings.Builder
 
 	// Build DROP statement
-	builder.WriteString(fmt.Sprintf("DROP MATERIALIZED VIEW %s", viewName))
+	builder.WriteString(fmt.Sprintf("DROP MATERIALIZED VIEW %s", sanitizeIdentifier(viewName)))
 
 	// Add CASCADE if requested
 	if cascade {
@@ -245,7 +245,7 @@ func (t *DB) GetContinuousAggregateInfo(ctx context.Context, viewName string) (m
 	// Query for continuous aggregate information
 	query := fmt.Sprintf(`
 		WITH policy_info AS (
-			SELECT 
+			SELECT
 				ca.user_view_name,
 				p.schedule_interval,
 				p.start_offset,
@@ -257,13 +257,13 @@ func (t *DB) GetContinuousAggregateInfo(ctx context.Context, viewName string) (m
 			AND ca.view_name = '%s'
 		),
 		size_info AS (
-			SELECT 
+			SELECT
 				pg_size_pretty(pg_total_relation_size(format('%%I.%%I', schemaname, tablename)))
 				as view_size
 			FROM pg_tables
 			WHERE tablename = '%s'
 		)
-		SELECT 
+		SELECT
 			ca.view_name,
 			ca.view_schema,
 			ca.materialized_only,
@@ -277,18 +277,18 @@ func (t *DB) GetContinuousAggregateInfo(ctx context.Context, viewName string) (m
 			pi.end_offset,
 			si.view_size,
 			(
-				SELECT min(time_bucket) 
+				SELECT min(time_bucket)
 				FROM %s
 			) as min_time,
 			(
-				SELECT max(time_bucket) 
+				SELECT max(time_bucket)
 				FROM %s
 			) as max_time
 		FROM timescaledb_information.continuous_aggregates ca
 		LEFT JOIN policy_info pi ON pi.user_view_name = ca.user_view_name
 		CROSS JOIN size_info si
 		WHERE ca.view_name = '%s'
-	`, viewName, viewName, viewName, viewName, viewName)
+	`, sanitizeStringLiteral(viewName), sanitizeStringLiteral(viewName), sanitizeIdentifier(viewName), sanitizeIdentifier(viewName), sanitizeStringLiteral(viewName))
 
 	// Execute query
 	result, err := t.ExecuteSQLWithoutParams(ctx, query)

--- a/pkg/db/timescale/hypertable.go
+++ b/pkg/db/timescale/hypertable.go
@@ -3,8 +3,37 @@ package timescale
 import (
 	"context"
 	"fmt"
+	"regexp"
 	"strings"
 )
+
+// validIdentifier matches valid PostgreSQL identifiers (alphanumeric and underscores, not starting with number)
+var validIdentifier = regexp.MustCompile(`^[a-zA-Z_][a-zA-Z0-9_]*$`)
+
+// sanitizeIdentifier validates and escapes a SQL identifier.
+// If the identifier is valid (alphanumeric + underscore), it returns it as-is.
+// If it contains special characters, it quotes it using PostgreSQL double-quote syntax.
+// Returns empty string if identifier is empty or contains null bytes.
+func sanitizeIdentifier(identifier string) string {
+	if identifier == "" {
+		return ""
+	}
+	// Check for null bytes
+	if strings.Contains(identifier, "\x00") {
+		return ""
+	}
+	// If valid identifier without quoting needed
+	if validIdentifier.MatchString(identifier) {
+		return identifier
+	}
+	// Quote the identifier to handle special characters
+	return "\"" + strings.ReplaceAll(identifier, "\"", "\"\"") + "\""
+}
+
+// sanitizeStringLiteral escapes a string literal by replacing ' with ”
+func sanitizeStringLiteral(s string) string {
+	return strings.ReplaceAll(s, "'", "''")
+}
 
 // HypertableConfig defines configuration for creating a hypertable
 type HypertableConfig struct {
@@ -39,12 +68,15 @@ func (t *DB) CreateHypertable(ctx context.Context, config HypertableConfig) erro
 	var queryBuilder strings.Builder
 	queryBuilder.WriteString("SELECT create_hypertable(")
 
-	// Table name and time column are required
-	queryBuilder.WriteString(fmt.Sprintf("'%s', '%s'", config.TableName, config.TimeColumn))
+	// Table name and time column are required (use identifiers, not string literals)
+	queryBuilder.WriteString(sanitizeIdentifier(config.TableName))
+	queryBuilder.WriteString(", ")
+	queryBuilder.WriteString(sanitizeIdentifier(config.TimeColumn))
 
 	// Optional parameters
 	if config.PartitioningColumn != "" {
-		queryBuilder.WriteString(fmt.Sprintf(", partition_column => '%s'", config.PartitioningColumn))
+		queryBuilder.WriteString(", partition_column => ")
+		queryBuilder.WriteString(sanitizeIdentifier(config.PartitioningColumn))
 	}
 
 	if config.ChunkTimeInterval != "" {
@@ -80,8 +112,8 @@ func (t *DB) AddDimension(ctx context.Context, tableName, columnName string, num
 		return fmt.Errorf("TimescaleDB extension not available")
 	}
 
-	query := fmt.Sprintf("SELECT add_dimension('%s', '%s', number_partitions => %d)",
-		tableName, columnName, numPartitions)
+	query := fmt.Sprintf("SELECT add_dimension(%s, %s, number_partitions => %d)",
+		sanitizeIdentifier(tableName), sanitizeIdentifier(columnName), numPartitions)
 
 	_, err := t.ExecuteSQLWithoutParams(ctx, query)
 	if err != nil {
@@ -143,8 +175,8 @@ func (t *DB) ListHypertables(ctx context.Context) ([]Hypertable, error) {
 
 		// Check if compression is enabled
 		compQuery := fmt.Sprintf(
-			"SELECT count(*) > 0 as is_compressed FROM timescaledb_information.compression_settings WHERE hypertable_name = '%s'",
-			ht.TableName,
+			"SELECT count(*) > 0 as is_compressed FROM timescaledb_information.compression_settings WHERE hypertable_name = %s",
+			sanitizeIdentifier(ht.TableName),
 		)
 		compResult, err := t.ExecuteSQLWithoutParams(ctx, compQuery)
 		if err == nil {
@@ -157,8 +189,8 @@ func (t *DB) ListHypertables(ctx context.Context) ([]Hypertable, error) {
 
 		// Check if retention policy is enabled
 		retQuery := fmt.Sprintf(
-			"SELECT count(*) > 0 as has_retention FROM timescaledb_information.jobs WHERE hypertable_name = '%s' AND proc_name = 'policy_retention'",
-			ht.TableName,
+			"SELECT count(*) > 0 as has_retention FROM timescaledb_information.jobs WHERE hypertable_name = %s AND proc_name = 'policy_retention'",
+			sanitizeIdentifier(ht.TableName),
 		)
 		retResult, err := t.ExecuteSQLWithoutParams(ctx, retQuery)
 		if err == nil {
@@ -185,16 +217,16 @@ func (t *DB) GetHypertable(ctx context.Context, tableName string) (*Hypertable, 
 		SELECT h.table_name, h.schema_name, d.column_name as time_column,
 			count(d.id) as num_dimensions,
 			(
-				SELECT column_name FROM _timescaledb_catalog.dimension 
-				WHERE hypertable_id = h.id AND column_type != 'TIMESTAMP' 
-				AND column_type != 'TIMESTAMPTZ' 
+				SELECT column_name FROM _timescaledb_catalog.dimension
+				WHERE hypertable_id = h.id AND column_type != 'TIMESTAMP'
+				AND column_type != 'TIMESTAMPTZ'
 				LIMIT 1
 			) as space_column
 		FROM _timescaledb_catalog.hypertable h
 		JOIN _timescaledb_catalog.dimension d ON h.id = d.hypertable_id
-		WHERE h.table_name = '%s'
+		WHERE h.table_name = %s
 		GROUP BY h.id, h.table_name, h.schema_name
-	`, tableName)
+	`, sanitizeIdentifier(tableName))
 
 	result, err := t.ExecuteSQLWithoutParams(ctx, query)
 	if err != nil {
@@ -263,7 +295,7 @@ func (t *DB) DropHypertable(ctx context.Context, tableName string, cascade bool)
 	}
 
 	// Build the DROP TABLE query
-	query := fmt.Sprintf("DROP TABLE %s", tableName)
+	query := fmt.Sprintf("DROP TABLE %s", sanitizeIdentifier(tableName))
 	if cascade {
 		query += " CASCADE"
 	}
@@ -284,11 +316,11 @@ func (t *DB) CheckIfHypertable(ctx context.Context, tableName string) (bool, err
 
 	query := fmt.Sprintf(`
 		SELECT EXISTS (
-			SELECT 1 
+			SELECT 1
 			FROM _timescaledb_catalog.hypertable
-			WHERE table_name = '%s'
+			WHERE table_name = %s
 		) as is_hypertable
-	`, tableName)
+	`, sanitizeIdentifier(tableName))
 
 	result, err := t.ExecuteSQLWithoutParams(ctx, query)
 	if err != nil {
@@ -320,15 +352,15 @@ func (t *DB) RecentChunks(ctx context.Context, tableName string, limit int) (int
 	}
 
 	query := fmt.Sprintf(`
-		SELECT 
+		SELECT
 			chunk_name,
 			range_start,
 			range_end
 		FROM timescaledb_information.chunks
-		WHERE hypertable_name = '%s'
+		WHERE hypertable_name = %s
 		ORDER BY range_end DESC
 		LIMIT %d
-	`, tableName, limit)
+	`, sanitizeIdentifier(tableName), limit)
 
 	result, err := t.ExecuteSQLWithoutParams(ctx, query)
 	if err != nil {

--- a/pkg/db/timescale/query.go
+++ b/pkg/db/timescale/query.go
@@ -271,7 +271,7 @@ func (t *DB) DownsampleTimeSeries(ctx context.Context, options DownsampleOptions
 	// Create the destination table if requested
 	if options.CreateTable {
 		// Get source table columns
-		schemaQuery := fmt.Sprintf("SELECT column_name, data_type FROM information_schema.columns WHERE table_name = '%s'", options.SourceTable)
+		schemaQuery := fmt.Sprintf("SELECT column_name, data_type FROM information_schema.columns WHERE table_name = %s", sanitizeIdentifier(options.SourceTable))
 		result, err := t.ExecuteSQLWithoutParams(ctx, schemaQuery)
 		if err != nil {
 			return fmt.Errorf("failed to get source table schema: %w", err)
@@ -284,7 +284,7 @@ func (t *DB) DownsampleTimeSeries(ctx context.Context, options DownsampleOptions
 
 		// Build CREATE TABLE statement
 		var createStmt strings.Builder
-		createStmt.WriteString(fmt.Sprintf("CREATE TABLE IF NOT EXISTS %s (", options.DestTable))
+		createStmt.WriteString(fmt.Sprintf("CREATE TABLE IF NOT EXISTS %s (", sanitizeIdentifier(options.DestTable)))
 
 		// Add time bucket column
 		createStmt.WriteString("time_bucket timestamptz, ")
@@ -374,7 +374,7 @@ func (t *DB) DownsampleTimeSeries(ctx context.Context, options DownsampleOptions
 		}
 	}
 
-	insertStmt.WriteString(fmt.Sprintf(" FROM %s", options.SourceTable))
+	insertStmt.WriteString(fmt.Sprintf(" FROM %s", sanitizeIdentifier(options.SourceTable)))
 
 	// Add WHERE clause if specified
 	if options.WhereCondition != "" {


### PR DESCRIPTION
## Summary
- Add `sanitizeIdentifier()` and `sanitizeStringLiteral()` helpers to validate and escape SQL identifiers/literals
- Apply sanitization to all `fmt.Sprintf` interpolations handling user-provided table/view names, column names in TimescaleDB functions
- Fixes critical SQL injection vulnerabilities in `hypertable.go`, `query.go`, and `continuous_aggregate.go`

## Root Cause
Multiple TimescaleDB functions used `fmt.Sprintf` to interpolate table names, column names, and view names directly into SQL queries without validation. An attacker could provide malicious input to execute arbitrary SQL.

## Changes
- `pkg/db/timescale/hypertable.go`: Added sanitization to `CreateHypertable`, `AddDimension`, `DropHypertable`, `CheckIfHypertable`, `RecentChunks`, and schema queries
- `pkg/db/timescale/query.go`: Added sanitization to `DownsampleTimeSeries`
- `pkg/db/timescale/continuous_aggregate.go`: Added sanitization to `CreateContinuousAggregate`, `RefreshContinuousAggregate`, `AddContinuousAggregatePolicy`, `RemoveContinuousAggregatePolicy`, `DropContinuousAggregate`, `GetContinuousAggregateInfo`

## Test plan
- [x] `go build ./...` passes
- [x] `golangci-lint run` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)