### PR TITLE
fix: close log file handle and log schema query failures

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -304,6 +304,11 @@ func main() {
 		} else {
 			// Redirect all standard logging to the file
 			log.SetOutput(logFile)
+			defer func() {
+				if closeErr := logFile.Close(); closeErr != nil {
+					fmt.Fprintf(os.Stderr, "Failed to close log file: %v\n", closeErr)
+				}
+			}()
 		}
 
 		// Critical: Use ServeStdio WITHOUT any console output to stdout

--- a/pkg/dbtools/dbtools.go
+++ b/pkg/dbtools/dbtools.go
@@ -1072,7 +1072,8 @@ func getBasicSchemaInfo(ctx context.Context, db db.Database, dbID, dbType string
 
 	rows, err := db.Query(ctx, query)
 	if err != nil {
-		// Return empty schema if query fails
+		// Log the error but return empty schema to avoid breaking the tool
+		logger.Warn("Failed to get basic schema for database %s: %v", dbID, err)
 		return result
 	}
 	defer func() {


### PR DESCRIPTION
## Summary
- Close logFile handle when stdio server exits to prevent file descriptor leak
- Log error when basic schema query fails instead of silently returning empty result

## Changes
1. `cmd/server/main.go`: Added deferred close of logFile when opened for stdio server logging
2. `pkg/dbtools/dbtools.go`: Added warning log when schema query fails

## Test plan
- [x] `go build ./...` passes
- [x] `golangci-lint run` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)