### PR TITLE
fix: handle []map[string]interface{} content in FormatResponse

### DIFF
--- a/internal/delivery/mcp/response.go
+++ b/internal/delivery/mcp/response.go
@@ -88,8 +88,18 @@ func FormatResponse(response interface{}, err error) (interface{}, error) {
 		}
 
 		if content, exists := respMap["content"]; exists {
-			if contentSlice, isSlice := content.([]interface{}); isSlice {
-				// If content is an empty slice, return a new empty response
+			// Accept both []interface{} (from JSON-decoded input) and
+			// []map[string]interface{} (typical handler return type).
+			// Without this, handler maps fall through to the default
+			// fmt.Sprintf("%v", response) branch and the MCP envelope
+			// gets Go-stringified into the outer text content.
+			switch contentSlice := content.(type) {
+			case []interface{}:
+				if len(contentSlice) == 0 {
+					return NewResponse(), nil
+				}
+				return respMap, nil
+			case []map[string]interface{}:
 				if len(contentSlice) == 0 {
 					return NewResponse(), nil
 				}

--- a/internal/delivery/mcp/response_test.go
+++ b/internal/delivery/mcp/response_test.go
@@ -141,6 +141,18 @@ func TestFormatResponse(t *testing.T) {
 			useMock:        false,
 		},
 		{
+			name: "map with concrete typed content slice",
+			input: map[string]interface{}{
+				"content": []map[string]interface{}{
+					{"type": "text", "text": "Typed content"},
+				},
+			},
+			err:            nil,
+			expectError:    false,
+			expectedOutput: `{"content":[{"text":"Typed content","type":"text"}]}`,
+			useMock:        false,
+		},
+		{
 			name:           "empty map response",
 			input:          map[string]interface{}{},
 			err:            nil,
@@ -175,6 +187,62 @@ func TestFormatResponse(t *testing.T) {
 					_ = err    // intentionally ignored in this test
 				}
 			}
+		})
+	}
+}
+
+// TestFormatResponse_ContentSliceTypes locks in that FormatResponse passes
+// through handler maps whose "content" field is either []interface{} or
+// []map[string]interface{}. Prior behavior only accepted []interface{},
+// causing []map[string]interface{} to fall through to the default
+// fmt.Sprintf("%v", response) branch and double-wrap the MCP envelope.
+func TestFormatResponse_ContentSliceTypes(t *testing.T) {
+	cases := []struct {
+		name     string
+		input    interface{}
+		expected string
+	}{
+		{
+			name: "content as []interface{}",
+			input: map[string]interface{}{
+				"content": []interface{}{
+					map[string]interface{}{"type": "text", "text": "hi"},
+				},
+			},
+			expected: `{"content":[{"text":"hi","type":"text"}]}`,
+		},
+		{
+			name: "content as []map[string]interface{} (handler return type)",
+			input: map[string]interface{}{
+				"content": []map[string]interface{}{
+					{"type": "text", "text": "hi"},
+				},
+			},
+			expected: `{"content":[{"text":"hi","type":"text"}]}`,
+		},
+		{
+			name: "content with metadata preserved",
+			input: map[string]interface{}{
+				"content": []map[string]interface{}{
+					{"type": "text", "text": "tx done"},
+				},
+				"metadata": map[string]interface{}{"transactionId": "tx_123"},
+			},
+			expected: `{"content":[{"text":"tx done","type":"text"}],"metadata":{"transactionId":"tx_123"}}`,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			resp, err := FormatResponse(tc.input, nil)
+			assert.NoError(t, err)
+			out, err := json.Marshal(resp)
+			assert.NoError(t, err)
+			assert.JSONEq(t, tc.expected, string(out))
+			// Defensive: make sure the Go map fmt string did NOT leak
+			// into the marshaled output.
+			assert.NotContains(t, string(out), "map[",
+				"FormatResponse double-wrapped the envelope via fmt.Sprintf(\"%%v\", response)")
 		})
 	}
 }


### PR DESCRIPTION
## Summary

- Fix MCP envelope double-wrap in `internal/delivery/mcp/response.go` `FormatResponse`
- Tool handlers in `internal/delivery/mcp/tool_types.go` and `pkg/dbtools/dbtools.go` return responses where `content` is a `[]map[string]interface{}`. The existing type assertion only matched `[]interface{}`, so these returns fell through to `return FromString(fmt.Sprintf("%v", response)), nil` and the entire MCP envelope was Go-stringified into the outer `content[0].text` field
- Accept both `[]interface{}` and `[]map[string]interface{}` via a Go type switch; existing empty-slice and metadata-preservation semantics are unchanged
- Add `TestFormatResponse_ContentSliceTypes` that actually asserts the marshaled JSON shape — the existing `TestFormatResponse` loop discards return values and only verifies absence of panic, which is why this regression went unnoticed

## Symptom

Calling any tool against a running server (here `query_<db>`) yields:

```json
{
  "content": [{
    "type": "text",
    "text": "map[content:[map[text:Results:\n\none\tmsg\n--------------------------------------------------------------------------------\n1\thi\n\nTotal rows: 1 type:text]]]"
  }]
}
```

Instead of:

```json
{
  "content": [{
    "type": "text",
    "text": "Results:\n\none\tmsg\n--------------------------------------------------------------------------------\n1\thi\n\nTotal rows: 1"
  }]
}
```

Reproduces against `freepeak/db-mcp-server:latest` for `query_<db>`, `execute_<db>`, `schema_<db>`, `transaction_<db>`, `performance_<db>`, `list_databases`, and `list`. The `timescaledb_*` tools use a separate formatter path and are not affected, which helped isolate the bug to `FormatResponse`.

## Root cause

`internal/delivery/mcp/response.go` (before this change):

```go
if respMap, ok := response.(map[string]interface{}); ok {
    ...
    if content, exists := respMap["content"]; exists {
        if contentSlice, isSlice := content.([]interface{}); isSlice {
            if len(contentSlice) == 0 {
                return NewResponse(), nil
            }
            return respMap, nil
        }
    }
    ...
}
return FromString(fmt.Sprintf("%v", response)), nil
```

Handler return shape is `map[string]interface{}{"content": []map[string]interface{}{...}}` — concrete element type, not `[]interface{}`. The assertion fails, control flows past both inner `if` blocks, and the catch-all at the bottom Go-stringifies the entire envelope.

## Fix

Replace the single-type assertion with a type switch covering both shapes. Inline comment in the source explains why both appear at the boundary.

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./internal/delivery/mcp/...` — 11/11 PASS, including 3 new sub-cases in `TestFormatResponse_ContentSliceTypes`:
  - `content as []interface{}` (locks in backward compat)
  - `content as []map[string]interface{} (handler return type)` (new behavior)
  - `content with metadata preserved`
- [x] `go test ./...` passes for all packages (excluding `pkg/db.TestRegressionAllDatabases` which requires live MySQL/PostgreSQL on localhost — pre-existing, unrelated to this change)
- [x] `golangci-lint run --timeout=5m ./internal/delivery/mcp/...` passes (exit 0, no warnings)
- [x] End-to-end smoke against a locally-built image: 32/32 tool sub-checks pass; outer text no longer contains `map[content:...]`. Verified against a 2-DB PostgreSQL+TimescaleDB config.

## Notes

The new test case includes an `assert.NotContains(out, "map[")` defense-in-depth check so this same class of regression cannot silently come back through any other fall-through path in `FormatResponse`.