### PR TITLE
fix(db): propagate query_timeout into MySQL DSN (#29)

### DIFF
--- a/pkg/db/db.go
+++ b/pkg/db/db.go
@@ -450,8 +450,15 @@ func NewDatabase(config Config) (Database, error) {
 	switch config.Type {
 	case "mysql":
 		driverName = "mysql"
-		dsn = fmt.Sprintf("%s:%s@tcp(%s:%d)/%s?parseTime=true",
-			config.User, config.Password, config.Host, config.Port, config.Name)
+		mysqlParams := []string{"parseTime=true"}
+		if config.ConnectTimeout > 0 {
+			mysqlParams = append(mysqlParams, fmt.Sprintf("timeout=%ds", config.ConnectTimeout))
+			mysqlParams = append(mysqlParams, fmt.Sprintf("readTimeout=%ds", config.QueryTimeout))
+			mysqlParams = append(mysqlParams, fmt.Sprintf("writeTimeout=%ds", config.QueryTimeout))
+		}
+		dsn = fmt.Sprintf("%s:%s@tcp(%s:%d)/%s?%s",
+			config.User, config.Password, config.Host, config.Port, config.Name,
+			strings.Join(mysqlParams, "&"))
 	case "postgres":
 		driverName = "postgres"
 		dsn = buildPostgresConnStr(config)
@@ -624,8 +631,13 @@ func (d *database) ConnectionString() string {
 	// Return masked DSN (hide password)
 	switch d.config.Type {
 	case "mysql":
-		return fmt.Sprintf("%s:***@tcp(%s:%d)/%s",
+		masked := fmt.Sprintf("%s:***@tcp(%s:%d)/%s",
 			d.config.User, d.config.Host, d.config.Port, d.config.Name)
+		if d.config.ConnectTimeout > 0 {
+			masked += fmt.Sprintf("?timeout=%ds&readTimeout=%ds&writeTimeout=%ds",
+				d.config.ConnectTimeout, d.config.QueryTimeout, d.config.QueryTimeout)
+		}
+		return masked
 	case "postgres":
 		// Create a sanitized version of the connection string
 		params := make([]string, 0)

--- a/pkg/db/mysql_timeout_test.go
+++ b/pkg/db/mysql_timeout_test.go
@@ -1,0 +1,68 @@
+package db
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestNewDatabase_MySQLDSNIncludesQueryTimeout locks in the fix for
+// FreePeak/db-mcp-server issue #29: the user reported MySQL queries
+// hitting a 30-second deadline even though they had set a custom
+// query_timeout in config. The reason was that the MySQL DSN did not
+// propagate the configured timeouts to the driver; only the default
+// go-sql-driver/mysql 30s timeout applied.
+//
+// The fix wires ConnectTimeout and QueryTimeout into the MySQL DSN as
+// `timeout`, `readTimeout`, and `writeTimeout` query parameters, which
+// the driver uses to bound both connection establishment and per-query
+// read/write operations.
+func TestNewDatabase_MySQLDSNIncludesQueryTimeout(t *testing.T) {
+	cfg := Config{
+		Type:           "mysql",
+		Host:           "localhost",
+		Port:           3306,
+		User:           "user",
+		Password:       "password",
+		Name:           "testdb",
+		ConnectTimeout: 5,
+		QueryTimeout:   120,
+	}
+	// SetDefaults would set QueryTimeout to 30; reset after defaults to keep
+	// our explicit value intact for the DSN test.
+	cfg.SetDefaults()
+	cfg.ConnectTimeout = 5
+	cfg.QueryTimeout = 120
+
+	db, err := NewDatabase(cfg)
+	assert.NoError(t, err)
+	assert.NotNil(t, db)
+
+	connStr := db.ConnectionString()
+	assert.Contains(t, connStr, "timeout=5s", "DSN must include connect timeout (issue #29)")
+	assert.Contains(t, connStr, "readTimeout=120s", "DSN must include read timeout derived from query_timeout")
+	assert.Contains(t, connStr, "writeTimeout=120s", "DSN must include write timeout derived from query_timeout")
+}
+
+// TestNewDatabase_MySQLDSNNoTimeoutWhenUnset ensures the DSN still surfaces
+// driver defaults when ConnectTimeout is left at zero. NewDatabase runs
+// SetDefaults which populates ConnectTimeout=10 and QueryTimeout=30, so the
+// masked DSN will include those values; the contract is that the operator's
+// explicit zero is honored only when the defaults are disabled.
+func TestNewDatabase_MySQLDSNNoTimeoutWhenUnset(t *testing.T) {
+	cfg := Config{
+		Type: "mysql",
+		Host: "localhost",
+		Port: 3306,
+		User: "user",
+		Name: "testdb",
+	}
+	db, err := NewDatabase(cfg)
+	assert.NoError(t, err)
+	connStr := db.ConnectionString()
+	// The defaults are 10s connect / 30s query; assert those surface in the
+	// masked DSN so operators can see the effective timeout values.
+	assert.Contains(t, connStr, "timeout=10s", "DSN must surface default connect timeout")
+	assert.Contains(t, connStr, "readTimeout=30s", "DSN must surface default query timeout")
+	assert.Contains(t, connStr, "writeTimeout=30s", "DSN must surface default query timeout")
+}


### PR DESCRIPTION
Fixes #29

The MySQL DSN previously omitted timeout parameters, so the
go-sql-driver default 30s timeout applied regardless of the
`query_timeout` setting in config. This made MySQL queries time out at
30 seconds even when the operator had explicitly configured a longer
(or shorter) budget, which is exactly the symptom reported in issue #29.

Wire `ConnectTimeout` and `QueryTimeout` into the MySQL DSN as
`timeout`, `readTimeout`, and `writeTimeout` query parameters, and
surface the effective values in the masked `ConnectionString` so
operators can verify them.

Add regression tests covering both the configured and default cases.

Test plan:
- go test ./pkg/db/ -run TestNewDatabase_MySQLDSN passes
- go build ./... passes
- golangci-lint clean