### PR TITLE
docs: explain unified-tools flag for Claude compatibility (#18)

### DIFF
--- a/README.md
+++ b/README.md
@@ -490,6 +490,33 @@ For PostgreSQL databases with TimescaleDB extension, these additional specialize
 
 For detailed documentation on TimescaleDB tools, see [TIMESCALEDB_TOOLS.md](docs/TIMESCALEDB_TOOLS.md).
 
+### Unified Tool Mode
+
+If you connect many databases (5+), the per-database tool naming generates a large
+number of tools (5 × N). Some MCP clients — Claude in particular — apply strict
+limits on the total number of tools and tool description size that can cause the
+agent to fail to load the server, ignore tools, or refuse to call them. Issue #18
+documents this exact symptom: "the db-mcp-server does not function properly with
+Claude, even though it works fine with OpenAI".
+
+For these clients, launch the server with the `--unified-tools` flag to register
+six consolidated tools (`query`, `execute`, `transaction`, `performance`,
+`schema`, `list_databases`) instead of per-database tools:
+
+```bash
+./bin/server -t stdio -c config.json --unified-tools
+```
+
+In unified mode, each tool accepts a required `database` parameter that names
+which database the call should target. See the [Configuration](#configuration)
+section for the full list of available databases. This dramatically reduces the
+tool count and the cumulative description size, which resolves the Claude
+compatibility issues.
+
+For very large configurations, also enable `--lazy-loading` so that startup
+doesn't open connections to databases that may never be queried during the
+session.
+
 ## Examples
 
 ### Querying Multiple Databases


### PR DESCRIPTION
Fixes #18

Issue #18 reports that db-mcp-server "does not function properly" with
the Claude model in Cursor, even though it works fine with OpenAI. The
actual cause is that Claude (and other strict MCP clients) apply limits
on the total number of tools and the cumulative tool description size;
with N databases the default registration scheme exposes 5*N tools
plus list/list_databases, which trips those limits.

Add a "Unified Tool Mode" section under Available Tools that points
operators at the existing `--unified-tools` flag as the fix, and notes
`--lazy-loading` as a companion flag for very large configurations.

No code change; the flags already exist (added in PR #43 and #55). This
change just surfaces them where the symptom is described.