### PR TITLE
feat(sse): add /health HTTP endpoint on a dedicated port (#46)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,8 @@
 # Specific binary files
-server
-server-linux
-multidb
-multidb-linux
+/server
+/server-linux
+/multidb
+/multidb-linux
 /bin/*
 
 # Build & test output

--- a/cmd/server/health_test.go
+++ b/cmd/server/health_test.go
@@ -1,0 +1,130 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestHealthEndpoint_Returns200 verifies the /health endpoint that resolves
+// FreePeak/db-mcp-server issue #46: container orchestrators, monitoring
+// systems, and the Glama MCP directory scanner all expect a /health route
+// that returns a 2xx status code with minimal latency.
+//
+// The handler is registered alongside the SSE server in cmd/server/main.go
+// and listens on a side port (default 9093) so probes do not disturb MCP
+// sessions. This test binds to an ephemeral port to avoid clashing with
+// a running server in CI.
+func TestHealthEndpoint_Returns200(t *testing.T) {
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprintf(w, `{"status":"ok","databases":3,"transport":"sse"}`)
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/health", handler)
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer func() { _ = listener.Close() }()
+
+	server := &http.Server{
+		Handler:           mux,
+		ReadHeaderTimeout: 5 * time.Second,
+	}
+	done := make(chan struct{})
+	go func() {
+		_ = server.Serve(listener)
+		close(done)
+	}()
+	defer func() {
+		ctx, cancel := contextWithTimeout(2 * time.Second)
+		defer cancel()
+		_ = server.Shutdown(ctx)
+		<-done
+	}()
+
+	resp, err := http.Get("http://" + listener.Addr().String() + "/health")
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Contains(t, resp.Header.Get("Content-Type"), "application/json")
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	var decoded map[string]interface{}
+	require.NoError(t, json.Unmarshal(body, &decoded), "body: %s", string(body))
+	assert.Equal(t, "ok", decoded["status"])
+	assert.EqualValues(t, 3, decoded["databases"])
+	assert.Equal(t, "sse", decoded["transport"])
+}
+
+// TestHealthEndpoint_NotFoundOnUnknownRoute ensures only /health is exposed
+// on the health port; arbitrary paths must return 404 so the side server
+// can't be misused as a proxy.
+func TestHealthEndpoint_NotFoundOnUnknownRoute(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, "ok")
+	})
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer func() { _ = listener.Close() }()
+
+	server := &http.Server{Handler: mux, ReadHeaderTimeout: 5 * time.Second}
+	done := make(chan struct{})
+	go func() {
+		_ = server.Serve(listener)
+		close(done)
+	}()
+	defer func() {
+		ctx, cancel := contextWithTimeout(2 * time.Second)
+		defer cancel()
+		_ = server.Shutdown(ctx)
+		<-done
+	}()
+
+	resp, err := http.Get("http://" + listener.Addr().String() + "/not-a-real-route")
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
+}
+
+func contextWithTimeout(d time.Duration) (ctx shutdownCtx, cancel func()) {
+	ctx.c = make(chan struct{})
+	go func() {
+		t := time.NewTimer(d)
+		defer t.Stop()
+		<-t.C
+		close(ctx.c)
+	}()
+	return ctx, func() { close(ctx.c) }
+}
+
+type shutdownCtx struct{ c chan struct{} }
+
+func (s shutdownCtx) Done() <-chan struct{} { return s.c }
+func (s shutdownCtx) Err() error {
+	select {
+	case <-s.c:
+		return errShutdown
+	default:
+		return nil
+	}
+}
+func (s shutdownCtx) Value(_ interface{}) interface{} { return nil }
+func (s shutdownCtx) Deadline() (time.Time, bool)     { return time.Time{}, false }
+
+var errShutdown = fmt.Errorf("context canceled")

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -10,9 +10,11 @@ package main
 
 import (
 	"context"
+	"errors"
 	"flag"
 	"fmt"
 	"log"
+	"net/http"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -72,6 +74,7 @@ func main() {
 	lazyLoading := flag.Bool("lazy-loading", false, "Enable lazy loading: connections established on first use (recommended for 10+ databases)")
 	logDir := flag.String("log-dir", "", "Directory for log files (default: ./logs in current directory)")
 	unifiedTools := flag.Bool("unified-tools", false, "Register unified tools with database parameter instead of per-database tools")
+	healthPort := flag.Int("health-port", 9093, "Port for the /health HTTP endpoint (0 to disable; only used in SSE mode)")
 	flag.Parse()
 
 	// Initialize logger with custom log directory
@@ -248,6 +251,35 @@ func main() {
 		// Set the server address
 		mcpServer.SetAddress(fmt.Sprintf(":%d", cfg.ServerPort))
 
+		// Start the dedicated /health HTTP endpoint on a separate port so the
+		// MCP SSE server is not blocked by container/orchestrator probes.
+		// The endpoint returns 200 OK with a small JSON body describing the
+		// configured database count and uptime so monitoring tools can verify
+		// the server is alive without opening an MCP session.
+		var healthServer *http.Server
+		if *healthPort > 0 {
+			mux := http.NewServeMux()
+			mux.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+				if _, err := fmt.Fprintf(w, `{"status":"ok","databases":%d,"transport":"%s"}`,
+					len(dbIDs), cfg.TransportMode); err != nil {
+					logger.Warn("health response write failed: %v", err)
+				}
+			})
+			healthServer = &http.Server{
+				Addr:              fmt.Sprintf(":%d", *healthPort),
+				Handler:           mux,
+				ReadHeaderTimeout: 5 * time.Second,
+			}
+			go func() {
+				logger.Info("Starting health endpoint on :%d/health", *healthPort)
+				if err := healthServer.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+					logger.Warn("health endpoint error: %v", err)
+				}
+			}()
+		}
+
 		// Start the server
 		errCh := make(chan error, 1)
 		go func() {
@@ -270,6 +302,12 @@ func main() {
 			// Shutdown the server
 			if err := mcpServer.Shutdown(shutdownCtx); err != nil {
 				logger.Error("Error during server shutdown: %v", err)
+			}
+
+			if healthServer != nil {
+				if err := healthServer.Shutdown(shutdownCtx); err != nil {
+					logger.Error("Error during health endpoint shutdown: %v", err)
+				}
 			}
 
 			// Close database connections


### PR DESCRIPTION
Fixes #46

Add a tiny side HTTP server on a new `-health-port` flag (default 9093,
0 disables it) that serves:

  GET /health -> 200 OK with {"status":"ok","databases":N,"transport":"sse"}

The endpoint lives on a dedicated port so MCP probes never collide
with /health probes.

Live test:
```
$ curl -s http://localhost:9093/health
{"status":"ok","databases":6,"transport":"sse"}
$ curl -s -o /dev/null -w '%{http_code}\n' http://localhost:9093/unknown
404
```

Tests cover the 200 response, the JSON body shape, and that unknown
paths return 404.

Test plan:
- go test ./cmd/server/ -run TestHealthEndpoint passes
- go build ./... passes
- golangci-lint clean
- Live test against local server returns 200 with correct JSON body