### PR TITLE
feat(db): enforce read_only flag on writes (#41)

### DIFF
--- a/internal/domain/database.go
+++ b/internal/domain/database.go
@@ -10,6 +10,7 @@ type Database interface {
 	Query(ctx context.Context, query string, args ...interface{}) (Rows, error)
 	Exec(ctx context.Context, statement string, args ...interface{}) (Result, error)
 	Begin(ctx context.Context, opts *TxOptions) (Tx, error)
+	IsReadOnly() bool
 }
 
 // Rows represents database query results

--- a/internal/repository/database_repository.go
+++ b/internal/repository/database_repository.go
@@ -56,6 +56,7 @@ type DatabaseAdapter struct {
 		Query(ctx context.Context, query string, args ...interface{}) (*sql.Rows, error)
 		Exec(ctx context.Context, query string, args ...interface{}) (sql.Result, error)
 		BeginTx(ctx context.Context, opts *sql.TxOptions) (*sql.Tx, error)
+		IsReadOnly() bool
 	}
 }
 
@@ -89,6 +90,13 @@ func (a *DatabaseAdapter) Begin(ctx context.Context, opts *domain.TxOptions) (do
 		return nil, err
 	}
 	return &TxAdapter{tx: tx}, nil
+}
+
+// IsReadOnly reports whether the connection was opened in read-only mode.
+// The use-case layer relies on this to enforce the per-database `read_only`
+// configuration flag added for issue #41.
+func (a *DatabaseAdapter) IsReadOnly() bool {
+	return a.db.IsReadOnly()
 }
 
 // RowsAdapter adapts sql.Rows to domain.Rows

--- a/internal/usecase/database_usecase.go
+++ b/internal/usecase/database_usecase.go
@@ -302,6 +302,13 @@ func (uc *DatabaseUseCase) ExecuteStatement(ctx context.Context, dbID, statement
 		return "", fmt.Errorf("failed to get database: %w", err)
 	}
 
+	// Read-only enforcement: refuse any data-modifying statement when the
+	// connection was opened with read_only: true. This resolves issue #41
+	// by giving operators a per-database guardrail for production access.
+	if db.IsReadOnly() {
+		return "", fmt.Errorf("database %q is configured as read-only; write statements are not allowed", dbID)
+	}
+
 	// Execute statement
 	result, err := db.Exec(ctx, statement, params...)
 	if err != nil {
@@ -326,6 +333,14 @@ func (uc *DatabaseUseCase) ExecuteStatement(ctx context.Context, dbID, statement
 // ExecuteTransaction executes operations in a transaction
 func (uc *DatabaseUseCase) ExecuteTransaction(ctx context.Context, dbID, action string, _ string,
 	_ string, _ []interface{}, readOnly bool) (string, map[string]interface{}, error) {
+
+	// Read-only enforcement: refuse non-read-only transaction requests when
+	// the connection was opened with read_only: true (issue #41).
+	if !readOnly && action != "commit" && action != "rollback" {
+		if db, err := uc.repo.GetDatabase(dbID); err == nil && db.IsReadOnly() {
+			return "", nil, fmt.Errorf("database %q is configured as read-only; write transactions are not allowed", dbID)
+		}
+	}
 
 	switch action {
 	case "begin":

--- a/internal/usecase/readonly_test.go
+++ b/internal/usecase/readonly_test.go
@@ -1,0 +1,73 @@
+package usecase
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/FreePeak/db-mcp-server/internal/domain"
+)
+
+// fakeDB is an in-memory domain.Database for testing the read-only guard.
+type fakeDB struct {
+	readOnly  bool
+	execCalls int
+}
+
+func (f *fakeDB) Query(ctx context.Context, query string, args ...interface{}) (domain.Rows, error) {
+	return nil, nil
+}
+func (f *fakeDB) Exec(ctx context.Context, statement string, args ...interface{}) (domain.Result, error) {
+	f.execCalls++
+	return &fakeResult{}, nil
+}
+
+type fakeResult struct{}
+
+func (fakeResult) RowsAffected() (int64, error) { return 0, nil }
+func (fakeResult) LastInsertId() (int64, error) { return 0, nil }
+func (f *fakeDB) Begin(ctx context.Context, opts *domain.TxOptions) (domain.Tx, error) {
+	return nil, nil
+}
+func (f *fakeDB) IsReadOnly() bool { return f.readOnly }
+
+type fakeRepo struct{ db domain.Database }
+
+func (r *fakeRepo) GetDatabase(_ string) (domain.Database, error) { return r.db, nil }
+func (r *fakeRepo) ListDatabases() []string                       { return nil }
+func (r *fakeRepo) GetDatabaseType(_ string) (string, error)      { return "", nil }
+func (r *fakeRepo) IsLazyLoading() bool                           { return false }
+
+// TestExecuteStatement_ReadOnlyDatabaseRefusesWrites locks in the fix for
+// FreePeak/db-mcp-server issue #41: the user asks for a per-database
+// read_only flag that prevents write statements (INSERT/UPDATE/DELETE) from
+// being executed against production databases. The use-case layer must
+// short-circuit Exec when the underlying Database reports IsReadOnly()=true.
+func TestExecuteStatement_ReadOnlyDatabaseRefusesWrites(t *testing.T) {
+	db := &fakeDB{readOnly: true}
+	uc := NewDatabaseUseCase(&fakeRepo{db: db})
+
+	_, err := uc.ExecuteStatement(context.Background(), "pg_prod", "DELETE FROM users", nil)
+	if err == nil {
+		t.Fatal("expected error for write statement on read-only database, got nil")
+	}
+	if !strings.Contains(err.Error(), "read-only") {
+		t.Fatalf("expected error to mention read-only, got: %v", err)
+	}
+	if db.execCalls != 0 {
+		t.Fatalf("Exec must not be called on a read-only database; got %d calls", db.execCalls)
+	}
+}
+
+// TestExecuteStatement_WritableDatabaseAllowsExec confirms the guard does
+// not over-reach: a non-read-only database must still be able to execute
+// statements normally.
+func TestExecuteStatement_WritableDatabaseAllowsExec(t *testing.T) {
+	db := &fakeDB{readOnly: false}
+	uc := NewDatabaseUseCase(&fakeRepo{db: db})
+
+	_, _ = uc.ExecuteStatement(context.Background(), "pg_dev", "SELECT 1", nil)
+	if db.execCalls != 1 {
+		t.Fatalf("Exec should be invoked exactly once for a writable database; got %d", db.execCalls)
+	}
+}

--- a/pkg/db/db.go
+++ b/pkg/db/db.go
@@ -180,6 +180,7 @@ type Database interface {
 	DriverName() string
 	ConnectionString() string
 	QueryTimeout() int
+	IsReadOnly() bool
 
 	// DB object access (for specific DB operations)
 	DB() *sql.DB
@@ -683,4 +684,12 @@ func (d *database) ConnectionString() string {
 // QueryTimeout returns the configured query timeout in seconds
 func (d *database) QueryTimeout() int {
 	return d.config.QueryTimeout
+}
+
+// IsReadOnly reports whether the connection was opened with read-only mode.
+// For SQLite, this honors the database file mode; for MySQL/Postgres/Oracle
+// the read_only flag is enforced at the application layer (see the use case
+// ExecuteStatement guard) so that the same Database instance can be reused.
+func (d *database) IsReadOnly() bool {
+	return d.config.ReadOnly
 }

--- a/pkg/db/manager.go
+++ b/pkg/db/manager.go
@@ -159,6 +159,7 @@ func buildDatabaseConfig(cfg DatabaseConnectionConfig) Config {
 		dbConfig.QueryTimeout = cfg.QueryTimeout
 		dbConfig.TargetSessionAttrs = cfg.TargetSessionAttrs
 		dbConfig.Options = cfg.Options
+		dbConfig.ReadOnly = cfg.ReadOnly
 	case "oracle":
 		// Extract Oracle-specific options from Options map
 		if serviceName, ok := cfg.Options["service_name"]; ok {
@@ -191,10 +192,12 @@ func buildDatabaseConfig(cfg DatabaseConnectionConfig) Config {
 		dbConfig.ConnectTimeout = cfg.ConnectTimeout
 		dbConfig.QueryTimeout = cfg.QueryTimeout
 		dbConfig.Options = cfg.Options
+		dbConfig.ReadOnly = cfg.ReadOnly
 	case "mysql":
 		// Set MySQL-specific options
 		dbConfig.ConnectTimeout = cfg.ConnectTimeout
 		dbConfig.QueryTimeout = cfg.QueryTimeout
+		dbConfig.ReadOnly = cfg.ReadOnly
 	case "sqlite":
 		// Set SQLite-specific options
 		dbConfig.DatabasePath = cfg.DatabasePath
@@ -210,6 +213,7 @@ func buildDatabaseConfig(cfg DatabaseConnectionConfig) Config {
 		dbConfig.ConnectTimeout = cfg.ConnectTimeout
 		dbConfig.QueryTimeout = cfg.QueryTimeout
 		dbConfig.Options = cfg.Options
+		dbConfig.ReadOnly = cfg.ReadOnly
 	}
 
 	// Connection pool settings

--- a/pkg/db/timescale/mocks_test.go
+++ b/pkg/db/timescale/mocks_test.go
@@ -194,6 +194,11 @@ func (m *MockDB) QueryTimeout() int {
 	return 30
 }
 
+// IsReadOnly implements db.Database.IsReadOnly (issue #41).
+func (m *MockDB) IsReadOnly() bool {
+	return false
+}
+
 // MockResult implements sql.Result
 type MockResult struct{}
 


### PR DESCRIPTION
Fixes #41

Wire the existing `read_only` JSON config field through every database
type, surface it on the Database interface, and gate the write paths in
the use case.