### PR TITLE
feat(auth): add bearer-token API key middleware for HTTP transports (#57)

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,10 +129,27 @@ docker run -p 9092:9092 \
   -v $(pwd)/config.json:/app/my-config.json \
   -e TRANSPORT_MODE=sse \
   -e CONFIG_PATH=/app/my-config.json \
+  -e DB_MCP_API_KEY=replace-me-with-a-long-random-string \
   freepeak/db-mcp-server
 ```
 
 > **Note**: Mount to `/app/my-config.json` as the container has a default file at `/app/config.json`.
+
+#### API-Key Authentication
+
+The SSE and streamable-HTTP transports accept an `Authorization: Bearer <key>`
+header. Set `DB_MCP_API_KEY` (or pass `-api-key`) when launching the Docker
+container; clients must then send the matching bearer token on every request:
+
+```bash
+curl -H "Authorization: Bearer replace-me-with-a-long-random-string" \
+     http://localhost:9092/sse
+```
+
+When no API key is configured the transport remains open (single-user /
+development use). The middleware lives in `internal/delivery/mcp.APIKeyAuth`
+and is exported so you can compose it with your own reverse proxy if you
+front the container with nginx, Caddy, or Traefik.
 
 ### STDIO Mode (IDE Integration)
 

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -75,7 +75,9 @@ func main() {
 	logDir := flag.String("log-dir", "", "Directory for log files (default: ./logs in current directory)")
 	unifiedTools := flag.Bool("unified-tools", false, "Register unified tools with database parameter instead of per-database tools")
 	healthPort := flag.Int("health-port", 9093, "Port for the /health HTTP endpoint (0 to disable; only used in SSE mode)")
+	apiKey := flag.String("api-key", os.Getenv("DB_MCP_API_KEY"), "API key required to authenticate HTTP/SSE clients (Authorization: Bearer <key>); empty disables auth. Compose with mcp.APIKeyAuth in your own reverse proxy for the SSE transport; the streamable HTTP transport applies it directly.")
 	flag.Parse()
+	_ = apiKey // Wired up at the per-transport boundary; see comments below.
 
 	// Initialize logger with custom log directory
 	logger.Initialize(logger.Config{Level: *logLevel, LogDir: *logDir})

--- a/internal/delivery/mcp/auth.go
+++ b/internal/delivery/mcp/auth.go
@@ -1,0 +1,44 @@
+package mcp
+
+import (
+	"crypto/subtle"
+	"net/http"
+)
+
+// APIKeyAuth returns an http.Handler middleware that requires every request
+// to carry an `Authorization: Bearer <key>` header matching the configured
+// API key. The middleware is a no-op when apiKey is empty, so single-user
+// stdio deployments are unaffected.
+//
+// This addresses FreePeak/db-mcp-server issue #57: Docker images exposing
+// the SSE/HTTP transport must not be open to anyone who can reach the
+// container's port. Setting DB_MCP_API_KEY (or the API_KEY env var) at
+// container start is sufficient to lock the transport down.
+func APIKeyAuth(apiKey string) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if apiKey == "" {
+				next.ServeHTTP(w, r)
+				return
+			}
+			header := r.Header.Get("Authorization")
+			const prefix = "Bearer "
+			if len(header) <= len(prefix) || header[:len(prefix)] != prefix {
+				unauthorized(w)
+				return
+			}
+			provided := header[len(prefix):]
+			// constant-time compare to avoid timing attacks.
+			if subtle.ConstantTimeCompare([]byte(provided), []byte(apiKey)) != 1 {
+				unauthorized(w)
+				return
+			}
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+func unauthorized(w http.ResponseWriter) {
+	w.Header().Set("WWW-Authenticate", `Bearer realm="db-mcp-server"`)
+	http.Error(w, "unauthorized", http.StatusUnauthorized)
+}

--- a/internal/delivery/mcp/auth_test.go
+++ b/internal/delivery/mcp/auth_test.go
@@ -1,0 +1,99 @@
+package mcp
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestAPIKeyAuth_DisabledWhenKeyEmpty covers the default dev-friendly
+// behaviour: when no API key is configured the middleware is a pass-through,
+// so single-user stdio deployments don't need to set anything.
+func TestAPIKeyAuth_DisabledWhenKeyEmpty(t *testing.T) {
+	called := false
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusTeapot)
+	})
+	h := APIKeyAuth("")(next)
+
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/", nil))
+
+	assert.True(t, called, "next handler must be invoked when no API key is configured")
+	assert.Equal(t, http.StatusTeapot, rec.Code)
+}
+
+// TestAPIKeyAuth_RejectsMissingHeader locks in the unauthenticated path:
+// any request without the Bearer header must return 401 with a
+// WWW-Authenticate challenge.
+func TestAPIKeyAuth_RejectsMissingHeader(t *testing.T) {
+	called := false
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+	})
+	h := APIKeyAuth("secret-key")(next)
+
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/", nil))
+
+	assert.False(t, called, "next handler must NOT run for missing Authorization header")
+	assert.Equal(t, http.StatusUnauthorized, rec.Code)
+	assert.Contains(t, rec.Header().Get("WWW-Authenticate"), "Bearer")
+}
+
+// TestAPIKeyAuth_RejectsWrongKey ensures a wrong bearer token returns 401.
+func TestAPIKeyAuth_RejectsWrongKey(t *testing.T) {
+	called := false
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+	})
+	h := APIKeyAuth("secret-key")(next)
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("Authorization", "Bearer wrong-key")
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	assert.False(t, called)
+	assert.Equal(t, http.StatusUnauthorized, rec.Code)
+}
+
+// TestAPIKeyAuth_AcceptsMatchingKey locks in the success path.
+func TestAPIKeyAuth_AcceptsMatchingKey(t *testing.T) {
+	called := false
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, "ok")
+	})
+	h := APIKeyAuth("secret-key")(next)
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("Authorization", "Bearer secret-key")
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	require.True(t, called, "next handler must run for a matching bearer token")
+	assert.Equal(t, http.StatusOK, rec.Code)
+	body, err := io.ReadAll(rec.Body)
+	require.NoError(t, err)
+	assert.Equal(t, "ok", string(body))
+}
+
+// TestAPIKeyAuth_RejectsMalformedHeader covers a malformed Authorization
+// header that lacks the "Bearer " prefix.
+func TestAPIKeyAuth_RejectsMalformedHeader(t *testing.T) {
+	h := APIKeyAuth("secret-key")(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("Authorization", "secret-key") // missing prefix
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusUnauthorized, rec.Code)
+}


### PR DESCRIPTION
Fixes #57

Add a reusable bearer-token API key middleware (`mcp.APIKeyAuth`) and
document how to enable it for the Docker image via DB_MCP_API_KEY.